### PR TITLE
Tanda song count works when lead-in is an announcement

### DIFF
--- a/src/applescript/embrace/nowPlayingInfo.js
+++ b/src/applescript/embrace/nowPlayingInfo.js
@@ -46,7 +46,7 @@ set songX to "0" as integer \n\
 set songYSub to "0" as integer \n\
 \n\
 repeat \n\
-if genre of track (songCountX) contains "ortina" then \n\
+if genre of track (songCountX) contains "ortina" or grouping of track (songCountX) contains "nnounc" then \n\
 exit repeat \n\
 else \n\
 set songCountX to (songCountX + -1) \n\

--- a/src/applescript/iTunes/nowPlayingInfo.js
+++ b/src/applescript/iTunes/nowPlayingInfo.js
@@ -32,7 +32,7 @@ set songX to "0" as integer \n\
 set songYSub to "0" as integer \n\
 \n\
 repeat \n\
-if genre of track (songCountX) of current playlist contains "ortina" then \n\
+if genre of track (songCountX) of current playlist contains "ortina" or grouping of track (songCountX) of current playlist contains "nnounc" then \n\
 exit repeat \n\
 else \n\
 set songCountX to (songCountX + -1) \n\


### PR DESCRIPTION
Now uses either genre containing "ortina" OR grouping containing "nnounc" to determine first song of a tanda.